### PR TITLE
Add optionallyChangePassword method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ the following scenerios.
 * Register
 * Change password, with old password
 * Change password, without old password
+* Optionally change password, with old password
+* Optionally change password, without old password
 * Login
+
+
 
 See the code below for example usage syntax.
 
@@ -53,6 +57,18 @@ $this->validate($request, [
     'password' => PasswordRules::changePassword($request->email, $request->old_password),
 ]);
 
+// Optionally change password, without old password
+$this->validate($request, [
+    'old_password' => 'required',
+    'password' => PasswordRules::optionallyChangePassword($request->email),
+]);
+
+// Optionally change password, with old password
+$this->validate($request, [
+    'old_password' => 'required',
+    'password' => PasswordRules::optionallyChangePassword($request->email, $request->old_password),
+]);
+
 // Change password, without old password
 $this->validate($request, [
     'old_password' => 'required',
@@ -65,3 +81,7 @@ $this->validate($request, [
     'password' => PasswordRules::login(),
 ]);
 ```
+
+The `optionallyChangePassword` method supplies validation rules that are
+appropriate for forms in which the password can be optionally changed if 
+filled in.

--- a/src/PasswordRules.php
+++ b/src/PasswordRules.php
@@ -44,7 +44,7 @@ abstract class PasswordRules
             'nullable',
         ]);
 
-        foreach($rules as $key => $rule) {
+        foreach ($rules as $key => $rule) {
             if (is_string($rule) && $rule === 'required') {
                 unset($rules[$key]);
             }

--- a/src/PasswordRules.php
+++ b/src/PasswordRules.php
@@ -36,6 +36,23 @@ abstract class PasswordRules
         return $rules;
     }
 
+    public static function optionallyChangePassword($username, $oldPassword = null)
+    {
+        $rules = self::changePassword($username, $oldPassword);
+
+        $rules = array_merge($rules, [
+            'nullable',
+        ]);
+
+        foreach($rules as $key => $rule) {
+            if (is_string($rule) && $rule === 'required') {
+                unset($rules[$key]);
+            }
+        }
+
+        return $rules;
+    }
+
     public static function login()
     {
         return [

--- a/tests/Unit/PasswordRulesTest.php
+++ b/tests/Unit/PasswordRulesTest.php
@@ -14,6 +14,8 @@ class PasswordRulesTest extends TestCase
             PasswordRules::register('username'),
             PasswordRules::changePassword('username', 'oldPassword'),
             PasswordRules::changePassword('username'),
+            PasswordRules::optionallyChangePassword('username', 'oldPassword'),
+            PasswordRules::optionallyChangePassword('username'),
             PasswordRules::login(),
         ];
     }


### PR DESCRIPTION
This PR adds an `optionallyChangePassword` method that supplies validation rules appropriate for forms in which the password can be optionally changed if filled in.