### PR TITLE
Fix issue with conflicting ownership of cache files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.1",
         "illuminate/contracts": "^5.1",
-        "divineomega/laravel-password-exposed-validation-rule": "^1.2",
+        "divineomega/laravel-password-exposed-validation-rule": "v1.2.2",
         "illuminate/support": "^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR fixes a cache file ownership, by ensuring cache files are stored within the Laravel storage directory, not in a system-wide directory. 

It also fixes various unit test issues.

Fix is part of a dependency, so the PR consists of a version constraint bump.