### PR TITLE
Bump dependency version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
 - '7.1.18'
 - '7.2'
 - nightly
-- 'hhvm'
 matrix:
   allow_failures:
   - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.1",
         "illuminate/contracts": "^5.1",
-        "divineomega/laravel-password-exposed-validation-rule": "^1.2.3",
+        "divineomega/laravel-password-exposed-validation-rule": "^2.0.1",
         "illuminate/support": "^5.1"
     },
     "require-dev": {

--- a/tests/Unit/ContextSpecificWordsTest.php
+++ b/tests/Unit/ContextSpecificWordsTest.php
@@ -67,4 +67,10 @@ class ContextSpecificWordsTest extends TestCase
         $rule = (new ContextSpecificWords(self::$username));
         $this->assertEquals('The :attribute can not contain the word \'\'.', $rule->message());
     }
+
+    public function testShortUsernamesAreExcluded()
+    {
+        $rule = (new ContextSpecificWords('ca'));
+        $this->assertTrue($rule->passes('password', 'cat'));
+    }
 }


### PR DESCRIPTION
This PR simply bumps the `laravel-password-exposed-validation-rule` dependency version constraint to the latest version.

As a result of this, it also removes HHVM support. This will therefore require a new major release.