### PR TITLE
Fixed documentation on changing password with old password

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $this->validate($request, [
 // Change password, with old password
 $this->validate($request, [
     'old_password' => 'required',
-    'password' => PasswordRules::changePassword($request->email, $request->old_password),
+    'password' => PasswordRules::changePassword($request->email, 'old_password'),
 ]);
 
 // Change password, without old password
@@ -82,7 +82,7 @@ $this->validate($request, [
 // Optionally change password, with old password
 $this->validate($request, [
     'old_password' => 'required',
-    'password' => PasswordRules::optionallyChangePassword($request->email, $request->old_password),
+    'password' => PasswordRules::optionallyChangePassword($request->email, 'old_password'),
 ]);
 
 // Optionally change password, without old password


### PR DESCRIPTION
The "different" Laravel rule used here https://github.com/langleyfoxall/laravel-nist-password-rules/blob/8a0f2f5a37b31d0a3cbfea88f8583f0ea47e1ae9/src/PasswordRules.php#L36 takes the field name as parameter, not the value as the README says.

See: **different**:_field_ in [Laravel 5.8 Doc](https://laravel.com/docs/5.8/validation#rule-different)