### PR TITLE
Make password confirmation optional (but true by default) in register

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ $this->validate($request, [
     'password' => PasswordRules::register($request->email),
 ]);
 
+// Register, without requiring password confirmation
+$this->validate($request, [
+    'email' => 'required',
+    'password' => PasswordRules::register($request->email, false),
+]);
+
 // Change password, with old password
 $this->validate($request, [
     'old_password' => 'required',

--- a/src/PasswordRules.php
+++ b/src/PasswordRules.php
@@ -11,7 +11,7 @@ use LangleyFoxall\LaravelNISTPasswordRules\Rules\SequentialCharacters;
 
 abstract class PasswordRules
 {
-    public static function register($username, $confirmation = true)
+    public static function register($username, $requireConfirmation = true)
     {
         $rules = [
             'required',
@@ -19,7 +19,7 @@ abstract class PasswordRules
             'min:8',
         ];
 
-        if ($confirmation) {
+        if ($requireConfirmation) {
             $rules[] = 'confirmed';
         }
 

--- a/src/PasswordRules.php
+++ b/src/PasswordRules.php
@@ -11,20 +11,26 @@ use LangleyFoxall\LaravelNISTPasswordRules\Rules\SequentialCharacters;
 
 abstract class PasswordRules
 {
-    public static function register($username)
+    public static function register($username, $confirmation = true)
     {
-        return [
+        $rules = [
             'required',
             'string',
             'min:8',
-            'confirmed',
+        ];
+
+        if ($confirmation) {
+            $rules[] = 'confirmed';
+        }
+
+        return array_merge($rules, [
             new SequentialCharacters(),
             new RepetitiveCharacters(),
             new DictionaryWords(),
             new ContextSpecificWords($username),
             new DerivativesOfContextSpecificWords($username),
             new BreachedPasswords(),
-        ];
+        ]);
     }
 
     public static function changePassword($username, $oldPassword = null)


### PR DESCRIPTION
There has been more and more sites where the register page don't ask you to confirm password. Trusting that you can always rely on the reset password functionality if you forget your password.

Hence this PR make password confirmation optional (but true by default to not break backward compatibility).

Needed this in a recent site I'm building :).

Thank you.