### PR TITLE
Support PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: php
-dist: trusty
+dist: bionic
 php:
 - '7.1.18'
 - '7.2'
+- '7.3'
+- '7.4'
+- '8.0'
 - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 dist: bionic
 php:
-- '7.1.18'
 - '7.2'
 - '7.3'
 - '7.4'

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "laravel/framework": "^5.5||^6.0||^7.0||^8.0",
         "divineomega/laravel-password-exposed-validation-rule": "^2.4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.14.1",
         "php-coveralls/php-coveralls": "^2.0",
-        "orchestra/testbench": "^3.8.0"
+        "orchestra/testbench": "^5.17.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "fakerphp/faker": "^1.14.1",
         "php-coveralls/php-coveralls": "^2.0",
-        "orchestra/testbench": "^6.17.0"
+        "orchestra/testbench": "^3.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     "require": {
         "php": ">=7.1",
         "laravel/framework": "^5.5||^6.0||^7.0||^8.0",
-        "divineomega/laravel-password-exposed-validation-rule": "^2.3.0"
+        "divineomega/laravel-password-exposed-validation-rule": "^2.4.0"
     },
     "require-dev": {
-        "fzaninotto/faker": "^1.6",
+        "fakerphp/faker": "^1.14.1",
         "php-coveralls/php-coveralls": "^2.0",
-        "orchestra/testbench": "^3.4"
+        "orchestra/testbench": "^6.17.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,6 @@
     <testsuites>
         <testsuite name="Unit Tests">
             <directory suffix="Test.php">./tests/Unit</directory>
-            <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
- Adds 7.3, 7.4 and 8.0 to the list of tested PHP versions.
- Upgrades to Ubuntu Bionic for PHP 8.0 support.
- Updates `laravel-password-exposed-validation-rule` to ensure PHP 8.0 support.
- Updates Faker dependency for PHP 8.0 support.
- Testbench had to be updated to support newer Faker versions and newer Testbench versions do not support PHP 7.1.  This unfortunately had to be dropped to update.
- Removed a reference to a nonexistent test directory causing test run failures.