### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.2",
         "laravel/framework": "^5.5||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0",
-        "divineomega/laravel-password-exposed-validation-rule": "^4.0"
+        "divineomega/laravel-password-exposed-validation-rule": "^2.5.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.14.1|^1.9.1",


### PR DESCRIPTION
fix divineomega/laravel-password-exposed-validation-rule = 2.5.0