### PR TITLE
Invalid user target for laravel-password-exposed-validation-rule dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.2",
         "laravel/framework": "^5.5||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0",
-        "divineomega/laravel-password-exposed-validation-rule": "^4.0"
+        "langleyfoxall/laravel-password-exposed-validation-rule": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.14.1|^1.9.1",


### PR DESCRIPTION
fix: invalid user target for laravel-password-exposed-validation-rule dependancy

related : https://github.com/langleyfoxall/laravel-nist-password-rules/issues/62